### PR TITLE
Add length scale matching plots

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,7 +11,7 @@ We use dimensionless interaction parameters from the DEMO reference design:
 Calculate the characteristic length scales \( L \) for MHD similarity under constrained test conditions:
 - Magnetic field \( B = 4 \, \text{T} \)
 - Surface heat flux \( q'' = 0.1 \rightarrow 1.0 \, \text{MW/m²} \)
-- Flow rate \( Q = 0.5 \rightarrow 6.0 \, \text{m³/hr} \)
+- Flow velocity ( U = 1e-4 -> 5e-3 m/s )
 - Temperature-dependent material properties for:
   - PbLi alloy (density, viscosity, conductivity, thermal conductivity, expansion coefficient)
   - SS316L structure (used for comparison)

--- a/plotting.py
+++ b/plotting.py
@@ -57,3 +57,31 @@ def plot_Lha_Lre_u(L_ha, L_re, u_values, title="L_Ha vs L_Re vs velocity"):
     ax.set_title(title)
     fig.colorbar(surf, shrink=0.5, aspect=5)
     return fig, ax
+
+def plot_length_match(U, q, L, diff, threshold=1e-3, title="Characteristic length match"):
+    """Contour plot of characteristic length with match indication.
+
+    Parameters
+    ----------
+    U : ndarray
+        2D grid of flow velocity values in m/s.
+    q : ndarray
+        2D grid of surface heat flux values in MW/m^2.
+    L : ndarray
+        2D grid of averaged characteristic lengths [m].
+    diff : ndarray
+        2D grid of ``L_Ha - L_Gr`` differences.
+    threshold : float, optional
+        Contour level used to highlight where ``|L_Ha - L_Gr|`` is small.
+    title : str, optional
+        Plot title.
+    """
+    fig, ax = plt.subplots()
+    cf = ax.contourf(U, q, L, cmap="viridis")
+    cbar = fig.colorbar(cf, ax=ax)
+    cbar.set_label("L [m]")
+    ax.contour(U, q, np.abs(diff), levels=[threshold], colors="r")
+    ax.set_xlabel("U [m/s]")
+    ax.set_ylabel("q'' [MW/m^2]")
+    ax.set_title(title)
+    return fig, ax


### PR DESCRIPTION
## Summary
- add `plot_length_match` function for 2D contour of characteristic length
- sweep small flow velocities in `run_simulation`
- highlight region where $L_{Ha}\approx L_{Gr}$ and save plot for each temperature
- note updated velocity range in README

## Testing
- `python run_simulation.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684c6f4137dc832a892a017921066980